### PR TITLE
Update standard to v12

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ module.exports = (robot) => {
     app.use(require('express-sslify').HTTPS({ trustProtoHeader: true }))
   }
 
-  app.use(bodyParser.urlencoded({extended: true}))
+  app.use(bodyParser.urlencoded({ extended: true }))
 
   app.use('/static/', express.static(path.join(__dirname, 'static')))
 
@@ -114,14 +114,14 @@ module.exports = (robot) => {
       }
     }
 
-    res.render('index', {installations, info})
+    res.render('index', { installations, info })
   })
 
   app.get('/:owner', authenticate, getInstallations, findInstallation, async (req, res) => {
     const { installation } = res.locals
-    const { data: teams } = await req.github.orgs.getTeams({org: installation.account.login})
+    const { data: teams } = await req.github.orgs.getTeams({ org: installation.account.login })
 
-    res.render('new', {installation, teams})
+    res.render('new', { installation, teams })
   })
 
   app.post('/:owner', authenticate, getInstallations, findInstallation, async (req, res) => {
@@ -135,7 +135,7 @@ module.exports = (robot) => {
 
     // Ensure user has access to teams
     if (req.body.teams) {
-      const { data: visibleTeams } = await req.github.orgs.getTeams({org: installation.account.login})
+      const { data: visibleTeams } = await req.github.orgs.getTeams({ org: installation.account.login })
       options.teams = req.body.teams.filter(id => {
         return visibleTeams.filter(team => team.id === Number(id))
       })
@@ -149,7 +149,7 @@ module.exports = (robot) => {
 
     const link = `${req.protocol}://${req.get('host')}/join/${token}`
 
-    req.log({link, options}, 'Generating new token')
+    req.log({ link, options }, 'Generating new token')
     res.send(link)
   })
 
@@ -160,7 +160,7 @@ module.exports = (robot) => {
 
     const user = (await req.github.users.get({})).data
 
-    req.log({user, options}, 'Adding user to organization')
+    req.log({ user, options }, 'Adding user to organization')
 
     const github = await robot.auth(options.iss)
 
@@ -171,9 +171,9 @@ module.exports = (robot) => {
     })
 
     if (options.teams) {
-      robot.log({user, teams: options.teams}, 'Adding user to teams')
+      robot.log({ user, teams: options.teams }, 'Adding user to teams')
       await Promise.all(options.teams.map(async id => {
-        await github.orgs.addTeamMembership({id, username: user.login})
+        await github.orgs.addTeamMembership({ id, username: user.login })
       }))
     }
 

--- a/lib/oauth.js
+++ b/lib/oauth.js
@@ -1,12 +1,12 @@
 const request = require('request')
 const querystring = require('querystring')
-const {promisify} = require('util')
+const { promisify } = require('util')
 
 const post = promisify(request.post)
 
 module.exports = router => {
   router.get('/github/login', (req, res) => {
-    const protocol = req.headers["x-forwarded-proto"] || req.protocol
+    const protocol = req.headers['x-forwarded-proto'] || req.protocol
     const host = req.headers['x-forwarded-host'] || req.get('host')
 
     const params = querystring.stringify({
@@ -14,7 +14,7 @@ module.exports = router => {
       redirect_uri: `${protocol}://${host}/github/callback`
     })
     const url = `https://github.com/login/oauth/authorize?${params}`
-    req.log({url}, 'Redirecting to OAuth')
+    req.log({ url }, 'Redirecting to OAuth')
     res.redirect(url)
   })
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "localtunnel": "^1.8.2",
     "nock": "^9.1.5",
     "nodemon": "^1.18.3",
-    "standard": "^10.0.3",
+    "standard": "^12.0.1",
     "supertest": "^3.0.0"
   },
   "engines": {
@@ -36,6 +36,9 @@
   },
   "nodemonConfig": {
     "exec": "npm start",
-    "watch": [".env", "."]
+    "watch": [
+      ".env",
+      "."
+    ]
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -8,4 +8,4 @@ const robot = probot.load(app)
 
 nock.enableNetConnect('127.0.0.1')
 
-module.exports = {probot, robot}
+module.exports = { probot, robot }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,5 +1,5 @@
 const request = require('supertest')
-const {probot} = require('.')
+const { probot } = require('.')
 
 describe('Invitations', () => {
   describe('GET /', () => {

--- a/test/oauth.test.js
+++ b/test/oauth.test.js
@@ -1,6 +1,6 @@
 const request = require('supertest')
 const nock = require('nock')
-const {probot} = require('.')
+const { probot } = require('.')
 
 describe('OAuth', () => {
   describe('GET /github/login', () => {


### PR DESCRIPTION
This PR updates standard to [v12](https://standardjs.com/changelog.html#1200---2018-08-28) and runs `npx standard --fix` to fix any violations after updating.