### PR TITLE
Add GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET to .evn.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,10 @@
 APP_ID=
 WEBHOOK_SECRET=development
 
+# Required for authenticating users with GitHub
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
+
 # Uncomment this to get verbose logging
 # LOG_LEVEL=trace # or `info` to show less
 


### PR DESCRIPTION
This references issue #14 where the app requires it's client_id and client_secret to enable GitHub authentication.